### PR TITLE
Add the GNOME 3.26 backport PPA.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,18 @@ architectures:
   - build-on: i386
 
 parts:
+  gnome:
+    plugin: nil
+    build-packages:
+      - software-properties-common
+    override-pull: |
+      add-apt-repository -y ppa:ubuntu-desktop/gnome-3-26
+      apt -y update
+      apt -y upgrade
+
   brackets:
+    after:
+      - gnome
     plugin: nil
     override-build: |
       snapcraftctl build


### PR DESCRIPTION
This pull request enables the GNOME 3.26 PPA supported by the Ubuntu Desktop team. This fixes access to user fonts. Thanks @kenvandine!