### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,33 @@
 language: bash
-os: linux
-sudo: enabled
+dist: xenial
+
 env:
   global:
     - LC_ALL: C.UTF-8
     - LANG: C.UTF-8
+    - SNAPCRAFT_ENABLE_SILENT_REPORT: y
+    - SNAPCRAFT_ENABLE_DEVELOPER_DEBUG: y
 
-install:
+addons:
+  snaps:
+    - name: snapcraft
+      channel: stable
+      classic: true
+    - name: http
+    - name: transfer
+    - name: lxd
+      channel: stable
+
+script:
   - sudo apt update
-  - sudo apt install -y snapd
-  - sudo snap install lxd --channel 3.0/stable
-  - sudo snap install snapcraft --candidate --classic
+  - sudo /snap/bin/lxd.migrate -yes
   - sudo /snap/bin/lxd waitready
   - sudo /snap/bin/lxd init --auto
   - mkdir -p "$TRAVIS_BUILD_DIR/snaps-cache"
-script:
-  - export PATH=/snap/bin:$PATH
-  - sudo snapcraft cleanbuild
-  - sudo cp *.snap "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
+  - sudo snapcraft --use-lxd
 after_success:
-  - sudo snap install transfer
-  - timeout 180 sudo /snap/bin/transfer "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
+  - cp *.snap "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
+  - timeout 180 /snap/bin/transfer "$(echo "$TRAVIS_REPO_SLUG" | sed -e 's|.*/\(.*\)|\1|')-pr$TRAVIS_PULL_REQUEST.snap"
 after_failure:
   - sudo journalctl -u snapd
-  - sudo snap install http
-  - /snap/bin/http https://api.snapcraft.io/v2/snaps/info/core architecture==amd64 Snap-Device-Series:16
+  - http https://api.snapcraft.io/v2/snaps/info/core architecture==amd64 Snap-Device-Series:16

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
  built on top of web technologies such as HTML, CSS and JavaScript.
  The project was created and is maintained by Adobe, and is released
  under an MIT License.
+base: core18
 
 grade: stable
 confinement: classic

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,7 +53,7 @@ parts:
 
   brackets:
     after:
-      - gnome-desktop-platform
+      - desktop-gnome-platform
     plugin: nil
     override-build: |
       snapcraftctl build

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,6 +16,9 @@ architectures:
   - build-on: i386
 
 parts:
+  bsi-trigger: # A non-built part, only used to trigger builds in build.snapcraft.io on upstream changes
+    plugin: nil
+    source: https://github.com/adobe/brackets.git
   gnome:
     plugin: nil
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ parts:
     build-packages:
       - software-properties-common
     override-pull: |
-      add-apt-repository -y ppa:ubuntu-desktop/gnome-3-26
+      add-apt-repository -y ppa:ubuntu-desktop/gnome-3-28
       apt -y update
       apt -y upgrade
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,22 +16,44 @@ architectures:
   - build-on: amd64
   - build-on: i386
 
+plugs:
+  gnome-3-28-1804:
+    interface: content
+    target: $SNAP/gnome-platform
+    default-provider: gnome-3-28-1804
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes
+
 parts:
   bsi-trigger: # A non-built part, only used to trigger builds in build.snapcraft.io on upstream changes
     plugin: nil
     source: https://github.com/adobe/brackets.git
-  gnome:
-    plugin: nil
+  desktop-gnome-platform:
     build-packages:
-      - software-properties-common
-    override-pull: |
-      add-apt-repository -y ppa:ubuntu-desktop/gnome-3-28
-      apt -y update
-      apt -y upgrade
+    - build-essential
+    - libgtk-3-dev
+    make-parameters:
+    - FLAVOR=gtk3
+    override-build: |
+      snapcraftctl build
+      mkdir -pv $SNAPCRAFT_PART_INSTALL/gnome-platform
+    plugin: make
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: gtk
 
   brackets:
     after:
-      - gnome
+      - gnome-desktop-platform
     plugin: nil
     override-build: |
       snapcraftctl build


### PR DESCRIPTION
A non-built part, only used to trigger builds in build.snapcraft.io on upstream changes